### PR TITLE
Changed From 100 Pages per Book to 50

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-book.vonix.network

--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+book.vonix.network

--- a/src/utils/commandHandler.ts
+++ b/src/utils/commandHandler.ts
@@ -95,7 +95,7 @@ export default function returnCommands(
     amount_of_lines++;
 
     // If the amount of lines is 1400, or the index is the length of the lines array, create the command
-    if (amount_of_lines == 1400 || i == lines.length) {
+    if (amount_of_lines == 700 || i == lines.length) {
       // Create object containing info
       const params = {
         lines: copy_of_lines.splice(0, amount_of_lines),

--- a/src/utils/textHandler.ts
+++ b/src/utils/textHandler.ts
@@ -17,7 +17,7 @@ function createText(book: string[]): string {
       counter++;
 
       // If the index is divisible by 14, return the page string
-      if (counter == 14) {
+      if (counter == 13) {
         // Create text string
         lines = lines.trim();
         const pageString = lines;
@@ -63,7 +63,7 @@ export default function returnText(lines: string[]) {
     amount_of_lines++;
 
     // If the amount of lines is 14, or the index is the length of the lines array, create the text string
-    if (amount_of_lines == 14 || i == lines.length) {
+    if (amount_of_lines == 13 || i == lines.length) {
       // Create object containing info
       const params = {
         lines: copy_of_lines.splice(0, amount_of_lines),


### PR DESCRIPTION
The default limit in Minecraft for pages in a book is 50, and bedrock users cannot read the pages after the 50th page, they just come in blank